### PR TITLE
Config-File, Bug-Fixes, Styling

### DIFF
--- a/src/Components/DesktopNameForm.cs
+++ b/src/Components/DesktopNameForm.cs
@@ -32,9 +32,10 @@ public class DesktopNameForm : Form
         });
     }
 
-    public void Show(string displayName, Color backColor)
+    public void Show(string displayName, Color foreColor, Color backColor)
     {
         _displayLabel.Text = displayName;
+        _displayLabel.ForeColor = foreColor;
         
         Opacity = 1;
         BackColor = backColor;

--- a/src/Components/DesktopNameForm.cs
+++ b/src/Components/DesktopNameForm.cs
@@ -37,7 +37,7 @@ public class DesktopNameForm : Form
         _displayLabel.Text = displayName;
         _displayLabel.ForeColor = foreColor;
         
-        Opacity = 1;
+        Opacity = 0.5;
         BackColor = backColor;
 
         Width = TextRenderer.MeasureText(_displayLabel.Text, _displayLabel.Font).Width;

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -219,7 +219,7 @@ internal class DesktopNotifyIcon : IDisposable
     {
         User32.GetWindowText(User32.GetForegroundWindow(), _foregroundWindowTextBuffer, 256);
         
-        var taskViewOpened = _foregroundWindowTextBuffer.ToString().Equals("Task View");
+        var taskViewOpened = _foregroundWindowTextBuffer.ToString().Equals(Constants.TaskView);
 
         if (taskViewOpened)
         {

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -2,7 +2,6 @@
 using System.Drawing.Text;
 using System.Text;
 using Microsoft.Win32;
-using VirtualDesktopIndicator.Helpers;
 using VirtualDesktopIndicator.Native;
 using VirtualDesktopIndicator.Native.Constants;
 using VirtualDesktopIndicator.Native.Hooks;

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -383,7 +383,7 @@ internal class DesktopNotifyIcon : IDisposable
 
     private void ShowDesktopNameToast(int stayTime = 800, int fadeTime = 25, double fadeStep = 0.025)
     {
-        _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColorContrast, CurrentThemeColor);
+        _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColor, CurrentThemeColorContrast);
 
         _notificationAnimationThread?.Interrupt();
         _notificationAnimationThread = new(() =>

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -280,14 +280,12 @@ internal class DesktopNotifyIcon : IDisposable
     {
         if (eventArgs.Button == MouseButtons.Left)
         {
+            _taskViewClick = false;
+
             if (!_taskViewOpen)
             {
                 Shell32.ShellExecuteClsid(ClsIds.TaskView);
                 _taskViewClick = true;
-            }
-            else
-            {
-                _taskViewClick = false;
             }
         }
     }

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -33,7 +33,7 @@ internal class DesktopNotifyIcon : IDisposable
     private static readonly Dictionary<Theme, Color> ThemesColorContrasts = new()
     {
         {Theme.Dark, Color.Black},
-        {Theme.Light, Color.Wheat}
+        {Theme.Light, Color.White}
     };
 
     private Color CurrentThemeColor => ThemesColors[_systemTheme];

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -381,7 +381,7 @@ internal class DesktopNotifyIcon : IDisposable
         return menu;
     }
 
-    private void ShowDesktopNameToast(int stayTime = 800, int fadeTime = 25, double fadeStep = 0.025)
+    private void ShowDesktopNameToast(int stayTime = 1000, int fadeTime = 25, double fadeStep = 0.025)
     {
         _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColor, CurrentThemeColorContrast);
 

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -29,8 +29,15 @@ internal class DesktopNotifyIcon : IDisposable
         {Theme.Dark, Color.White},
         {Theme.Light, Color.Black},
     };
+    
+    private static readonly Dictionary<Theme, Color> ThemesColorContrasts = new()
+    {
+        {Theme.Dark, Color.Black},
+        {Theme.Light, Color.Wheat}
+    };
 
     private Color CurrentThemeColor => ThemesColors[_systemTheme];
+    private Color CurrentThemeColorContrast => ThemesColorContrasts[_systemTheme];
 
     private Theme _cachedSystemTheme;
     private Theme _systemTheme;
@@ -376,7 +383,7 @@ internal class DesktopNotifyIcon : IDisposable
 
     private void ShowDesktopNameToast(int stayTime = 800, int fadeTime = 25, double fadeStep = 0.025)
     {
-        _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColor);
+        _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColorContrast, CurrentThemeColor);
 
         _notificationAnimationThread?.Interrupt();
         _notificationAnimationThread = new(() =>

--- a/src/Config/UserConfig.cs
+++ b/src/Config/UserConfig.cs
@@ -5,7 +5,7 @@ namespace VirtualDesktopIndicator.Config;
 
 public class UserConfig
 {
-    public static UserConfig Current { get; } = LoadFromFile("vdi_config.json");
+    public static UserConfig Current { get; } = LoadFromFile(Constants.ConfigName);
 
     public bool NotificationsEnabled { get; set; } = true;
 

--- a/src/Config/UserConfig.cs
+++ b/src/Config/UserConfig.cs
@@ -1,0 +1,41 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VirtualDesktopIndicator.Config;
+
+public class UserConfig
+{
+    public static UserConfig Current { get; } = LoadFromFile("vdi_config.json");
+    
+    public bool NotificationsEnabled { get; set; }
+
+    [JsonIgnore]
+    private string _path;
+    
+    public UserConfig()
+    {
+    }
+    
+    private static UserConfig LoadFromFile(string path)
+    {
+        var config = new UserConfig();
+
+        if (!File.Exists(path))
+        {
+            config._path = path;
+            config.Save();
+        }
+        else
+        {
+            config = JsonSerializer.Deserialize<UserConfig>(File.ReadAllText(path)) ?? config;
+            config._path = path;
+        }
+        
+        return config;
+    }
+
+    public void Save()
+    {
+        File.WriteAllText(_path, JsonSerializer.Serialize(this));
+    }
+}

--- a/src/Config/UserConfig.cs
+++ b/src/Config/UserConfig.cs
@@ -6,8 +6,8 @@ namespace VirtualDesktopIndicator.Config;
 public class UserConfig
 {
     public static UserConfig Current { get; } = LoadFromFile("vdi_config.json");
-    
-    public bool NotificationsEnabled { get; set; }
+
+    public bool NotificationsEnabled { get; set; } = true;
 
     [JsonIgnore]
     private string _path;

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -5,4 +5,7 @@ namespace VirtualDesktopIndicator;
 public static class Constants
 {
     public static string AppName => Assembly.GetExecutingAssembly().GetName().Name ?? "VirtualDesktopIndicator";
+    
+    public const string ConfigName = "vdi_config.json";
+    public const string TaskView = "Task View";
 }

--- a/src/Native/VirtualDesktop/IVirtualDesktopManager.cs
+++ b/src/Native/VirtualDesktop/IVirtualDesktopManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace VirtualDesktopIndicator.Native.VirtualDesktop
 {
-    interface IVirtualDesktopManager
+    internal interface IVirtualDesktopManager
     {
         uint Current();
 

--- a/src/Utils/Autorun.cs
+++ b/src/Utils/Autorun.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Win32;
 
-namespace VirtualDesktopIndicator.Helpers
+namespace VirtualDesktopIndicator.Utils
 {
     internal static class Autorun
     {

--- a/src/Utils/RegistryMonitor.cs
+++ b/src/Utils/RegistryMonitor.cs
@@ -3,376 +3,375 @@ using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
 // Code from https://www.codeproject.com/Articles/4502/RegistryMonitor-a-NET-wrapper-class-for-RegNotifyC
-namespace VirtualDesktopIndicator.Utils
+namespace VirtualDesktopIndicator.Utils;
+
+/// <summary>
+/// <b>RegistryMonitor</b> allows you to monitor specific registry key.
+/// </summary>
+/// <remarks>
+/// If a monitored registry key changes, an event is fired. You can subscribe to these
+/// events by adding a delegate to <see cref="RegChanged"/>.
+/// <para>The Windows API provides a function
+/// <a href="http://msdn.microsoft.com/library/en-us/sysinfo/base/regnotifychangekeyvalue.asp">
+/// RegNotifyChangeKeyValue</a>, which is not covered by the
+/// <see cref="Microsoft.Win32.RegistryKey"/> class. <see cref="RegistryMonitor"/> imports
+/// that function and encapsulates it in a convenient manner.
+/// </para>
+/// </remarks>
+/// <example>
+/// This sample shows how to monitor <c>HKEY_CURRENT_USER\Environment</c> for changes:
+/// <code>
+/// public class MonitorSample
+/// {
+///     static void Main() 
+///     {
+///         RegistryMonitor monitor = new RegistryMonitor(RegistryHive.CurrentUser, "Environment");
+///         monitor.RegChanged += new EventHandler(OnRegChanged);
+///         monitor.Start();
+///
+///         while(true);
+/// 
+///			monitor.Stop();
+///     }
+///
+///     private void OnRegChanged(object sender, EventArgs e)
+///     {
+///         Console.WriteLine("registry key has changed");
+///     }
+/// }
+/// </code>
+/// </example>
+internal class RegistryMonitor : IDisposable
 {
+    #region P/Invoke
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern int RegOpenKeyEx(IntPtr hKey, string subKey, uint options, int samDesired,
+        out IntPtr phkResult);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern int RegNotifyChangeKeyValue(IntPtr hKey, bool bWatchSubtree,
+        RegChangeNotifyFilter dwNotifyFilter, IntPtr hEvent,
+        bool fAsynchronous);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern int RegCloseKey(IntPtr hKey);
+
+    private const int KEY_QUERY_VALUE = 0x0001;
+    private const int KEY_NOTIFY = 0x0010;
+    private const int STANDARD_RIGHTS_READ = 0x00020000;
+
+    private static readonly IntPtr HKEY_CLASSES_ROOT = new IntPtr(unchecked((int)0x80000000));
+    private static readonly IntPtr HKEY_CURRENT_USER = new IntPtr(unchecked((int)0x80000001));
+    private static readonly IntPtr HKEY_LOCAL_MACHINE = new IntPtr(unchecked((int)0x80000002));
+    private static readonly IntPtr HKEY_USERS = new IntPtr(unchecked((int)0x80000003));
+    private static readonly IntPtr HKEY_PERFORMANCE_DATA = new IntPtr(unchecked((int)0x80000004));
+    private static readonly IntPtr HKEY_CURRENT_CONFIG = new IntPtr(unchecked((int)0x80000005));
+    private static readonly IntPtr HKEY_DYN_DATA = new IntPtr(unchecked((int)0x80000006));
+
+    #endregion
+
+    #region Event handling
+
     /// <summary>
-    /// <b>RegistryMonitor</b> allows you to monitor specific registry key.
+    /// Occurs when the specified registry key has changed.
+    /// </summary>
+    public event EventHandler RegChanged;
+
+    /// <summary>
+    /// Raises the <see cref="RegChanged"/> event.
     /// </summary>
     /// <remarks>
-    /// If a monitored registry key changes, an event is fired. You can subscribe to these
-    /// events by adding a delegate to <see cref="RegChanged"/>.
-    /// <para>The Windows API provides a function
-    /// <a href="http://msdn.microsoft.com/library/en-us/sysinfo/base/regnotifychangekeyvalue.asp">
-    /// RegNotifyChangeKeyValue</a>, which is not covered by the
-    /// <see cref="Microsoft.Win32.RegistryKey"/> class. <see cref="RegistryMonitor"/> imports
-    /// that function and encapsulates it in a convenient manner.
-    /// </para>
+    /// <p>
+    /// <b>OnRegChanged</b> is called when the specified registry key has changed.
+    /// </p>
+    /// <note type="inheritinfo">
+    /// When overriding <see cref="OnRegChanged"/> in a derived class, be sure to call
+    /// the base class's <see cref="OnRegChanged"/> method.
+    /// </note>
     /// </remarks>
-    /// <example>
-    /// This sample shows how to monitor <c>HKEY_CURRENT_USER\Environment</c> for changes:
-    /// <code>
-    /// public class MonitorSample
-    /// {
-    ///     static void Main() 
-    ///     {
-    ///         RegistryMonitor monitor = new RegistryMonitor(RegistryHive.CurrentUser, "Environment");
-    ///         monitor.RegChanged += new EventHandler(OnRegChanged);
-    ///         monitor.Start();
-    ///
-    ///         while(true);
-    /// 
-    ///			monitor.Stop();
-    ///     }
-    ///
-    ///     private void OnRegChanged(object sender, EventArgs e)
-    ///     {
-    ///         Console.WriteLine("registry key has changed");
-    ///     }
-    /// }
-    /// </code>
-    /// </example>
-    internal class RegistryMonitor : IDisposable
+    protected virtual void OnRegChanged() => RegChanged?.Invoke(this, null);
+
+
+    /// <summary>
+    /// Occurs when the access to the registry fails.
+    /// </summary>
+    public event ErrorEventHandler Error;
+
+    /// <summary>
+    /// Raises the <see cref="Error"/> event.
+    /// </summary>
+    /// <param name="e">The <see cref="Exception"/> which occured while watching the registry.</param>
+    /// <remarks>
+    /// <p>
+    /// <b>OnError</b> is called when an exception occurs while watching the registry.
+    /// </p>
+    /// <note type="inheritinfo">
+    /// When overriding <see cref="OnError"/> in a derived class, be sure to call
+    /// the base class's <see cref="OnError"/> method.
+    /// </note>
+    /// </remarks>
+    protected virtual void OnError(Exception e) => Error?.Invoke(this, new ErrorEventArgs(e));
+
+    #endregion
+
+    #region Private member variables
+
+    private IntPtr _registryHive;
+    private string _registrySubName;
+    private object _threadLock = new object();
+    private Thread _thread;
+    private bool _disposed = false;
+    private ManualResetEvent _eventTerminate = new ManualResetEvent(false);
+
+    private RegChangeNotifyFilter _regFilter = RegChangeNotifyFilter.Key | RegChangeNotifyFilter.Attribute |
+                                               RegChangeNotifyFilter.Value | RegChangeNotifyFilter.Security;
+
+    #endregion
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
+    /// </summary>
+    /// <param name="registryKey">The registry key to monitor.</param>
+    public RegistryMonitor(RegistryKey registryKey)
     {
-        #region P/Invoke
+        InitRegistryKey(registryKey.Name);
+    }
 
-        [DllImport("advapi32.dll", SetLastError = true)]
-        private static extern int RegOpenKeyEx(IntPtr hKey, string subKey, uint options, int samDesired,
-                                               out IntPtr phkResult);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    public RegistryMonitor(string name)
+    {
+        if (name == null || name.Length == 0)
+            throw new ArgumentNullException("name");
 
-        [DllImport("advapi32.dll", SetLastError = true)]
-        private static extern int RegNotifyChangeKeyValue(IntPtr hKey, bool bWatchSubtree,
-                                                          RegChangeNotifyFilter dwNotifyFilter, IntPtr hEvent,
-                                                          bool fAsynchronous);
+        InitRegistryKey(name);
+    }
 
-        [DllImport("advapi32.dll", SetLastError = true)]
-        private static extern int RegCloseKey(IntPtr hKey);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
+    /// </summary>
+    /// <param name="registryHive">The registry hive.</param>
+    /// <param name="subKey">The sub key.</param>
+    public RegistryMonitor(RegistryHive registryHive, string subKey)
+    {
+        InitRegistryKey(registryHive, subKey);
+    }
 
-        private const int KEY_QUERY_VALUE = 0x0001;
-        private const int KEY_NOTIFY = 0x0010;
-        private const int STANDARD_RIGHTS_READ = 0x00020000;
+    /// <summary>
+    /// Disposes this object.
+    /// </summary>
+    public void Dispose()
+    {
+        Stop();
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
 
-        private static readonly IntPtr HKEY_CLASSES_ROOT = new IntPtr(unchecked((int)0x80000000));
-        private static readonly IntPtr HKEY_CURRENT_USER = new IntPtr(unchecked((int)0x80000001));
-        private static readonly IntPtr HKEY_LOCAL_MACHINE = new IntPtr(unchecked((int)0x80000002));
-        private static readonly IntPtr HKEY_USERS = new IntPtr(unchecked((int)0x80000003));
-        private static readonly IntPtr HKEY_PERFORMANCE_DATA = new IntPtr(unchecked((int)0x80000004));
-        private static readonly IntPtr HKEY_CURRENT_CONFIG = new IntPtr(unchecked((int)0x80000005));
-        private static readonly IntPtr HKEY_DYN_DATA = new IntPtr(unchecked((int)0x80000006));
-
-        #endregion
-
-        #region Event handling
-
-        /// <summary>
-        /// Occurs when the specified registry key has changed.
-        /// </summary>
-        public event EventHandler RegChanged;
-
-        /// <summary>
-        /// Raises the <see cref="RegChanged"/> event.
-        /// </summary>
-        /// <remarks>
-        /// <p>
-        /// <b>OnRegChanged</b> is called when the specified registry key has changed.
-        /// </p>
-        /// <note type="inheritinfo">
-        /// When overriding <see cref="OnRegChanged"/> in a derived class, be sure to call
-        /// the base class's <see cref="OnRegChanged"/> method.
-        /// </note>
-        /// </remarks>
-        protected virtual void OnRegChanged() => RegChanged?.Invoke(this, null);
-
-
-        /// <summary>
-        /// Occurs when the access to the registry fails.
-        /// </summary>
-        public event ErrorEventHandler Error;
-
-        /// <summary>
-        /// Raises the <see cref="Error"/> event.
-        /// </summary>
-        /// <param name="e">The <see cref="Exception"/> which occured while watching the registry.</param>
-        /// <remarks>
-        /// <p>
-        /// <b>OnError</b> is called when an exception occurs while watching the registry.
-        /// </p>
-        /// <note type="inheritinfo">
-        /// When overriding <see cref="OnError"/> in a derived class, be sure to call
-        /// the base class's <see cref="OnError"/> method.
-        /// </note>
-        /// </remarks>
-        protected virtual void OnError(Exception e) => Error?.Invoke(this, new ErrorEventArgs(e));
-
-        #endregion
-
-        #region Private member variables
-
-        private IntPtr _registryHive;
-        private string _registrySubName;
-        private object _threadLock = new object();
-        private Thread _thread;
-        private bool _disposed = false;
-        private ManualResetEvent _eventTerminate = new ManualResetEvent(false);
-
-        private RegChangeNotifyFilter _regFilter = RegChangeNotifyFilter.Key | RegChangeNotifyFilter.Attribute |
-                                                   RegChangeNotifyFilter.Value | RegChangeNotifyFilter.Security;
-
-        #endregion
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
-        /// </summary>
-        /// <param name="registryKey">The registry key to monitor.</param>
-        public RegistryMonitor(RegistryKey registryKey)
+    /// <summary>
+    /// Gets or sets the <see cref="RegChangeNotifyFilter">RegChangeNotifyFilter</see>.
+    /// </summary>
+    public RegChangeNotifyFilter RegChangeNotifyFilter
+    {
+        get => _regFilter;
+        set
         {
-            InitRegistryKey(registryKey.Name);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        public RegistryMonitor(string name)
-        {
-            if (name == null || name.Length == 0)
-                throw new ArgumentNullException("name");
-
-            InitRegistryKey(name);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RegistryMonitor"/> class.
-        /// </summary>
-        /// <param name="registryHive">The registry hive.</param>
-        /// <param name="subKey">The sub key.</param>
-        public RegistryMonitor(RegistryHive registryHive, string subKey)
-        {
-            InitRegistryKey(registryHive, subKey);
-        }
-
-        /// <summary>
-        /// Disposes this object.
-        /// </summary>
-        public void Dispose()
-        {
-            Stop();
-            _disposed = true;
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="RegChangeNotifyFilter">RegChangeNotifyFilter</see>.
-        /// </summary>
-        public RegChangeNotifyFilter RegChangeNotifyFilter
-        {
-            get => _regFilter;
-            set
-            {
-                lock (_threadLock)
-                {
-                    if (IsMonitoring)
-                        throw new InvalidOperationException("Monitoring thread is already running");
-
-                    _regFilter = value;
-                }
-            }
-        }
-
-        #region Initialization
-
-        private void InitRegistryKey(RegistryHive hive, string name)
-        {
-            switch (hive)
-            {
-                case RegistryHive.ClassesRoot:
-                    _registryHive = HKEY_CLASSES_ROOT;
-                    break;
-                case RegistryHive.CurrentConfig:
-                    _registryHive = HKEY_CURRENT_CONFIG;
-                    break;
-                case RegistryHive.CurrentUser:
-                    _registryHive = HKEY_CURRENT_USER;
-                    break;
-                case RegistryHive.LocalMachine:
-                    _registryHive = HKEY_LOCAL_MACHINE;
-                    break;
-                case RegistryHive.PerformanceData:
-                    _registryHive = HKEY_PERFORMANCE_DATA;
-                    break;
-                case RegistryHive.Users:
-                    _registryHive = HKEY_USERS;
-                    break;
-                default:
-                    throw new InvalidEnumArgumentException("hive", (int)hive, typeof(RegistryHive));
-            }
-            _registrySubName = name;
-        }
-
-        private void InitRegistryKey(string name)
-        {
-            string[] nameParts = name.Split('\\');
-
-            switch (nameParts[0])
-            {
-                case "HKEY_CLASSES_ROOT":
-                case "HKCR":
-                    _registryHive = HKEY_CLASSES_ROOT;
-                    break;
-
-                case "HKEY_CURRENT_USER":
-                case "HKCU":
-                    _registryHive = HKEY_CURRENT_USER;
-                    break;
-
-                case "HKEY_LOCAL_MACHINE":
-                case "HKLM":
-                    _registryHive = HKEY_LOCAL_MACHINE;
-                    break;
-
-                case "HKEY_USERS":
-                    _registryHive = HKEY_USERS;
-                    break;
-
-                case "HKEY_CURRENT_CONFIG":
-                    _registryHive = HKEY_CURRENT_CONFIG;
-                    break;
-
-                default:
-                    _registryHive = IntPtr.Zero;
-                    throw new ArgumentException("The registry hive '" + nameParts[0] + "' is not supported", "value");
-            }
-
-            _registrySubName = String.Join("\\", nameParts, 1, nameParts.Length - 1);
-        }
-
-        #endregion
-
-        /// <summary>
-        /// <b>true</b> if this <see cref="RegistryMonitor"/> object is currently monitoring;
-        /// otherwise, <b>false</b>.
-        /// </summary>
-        public bool IsMonitoring => _thread != null;
-
-        /// <summary>
-        /// Start monitoring.
-        /// </summary>
-        public void Start()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(null, "This instance is already disposed");
-
             lock (_threadLock)
             {
-                if (!IsMonitoring)
-                {
-                    _eventTerminate.Reset();
-                    _thread = new Thread(new ThreadStart(MonitorThread));
-                    _thread.IsBackground = true;
-                    _thread.Start();
-                }
+                if (IsMonitoring)
+                    throw new InvalidOperationException("Monitoring thread is already running");
+
+                _regFilter = value;
             }
         }
+    }
 
-        /// <summary>
-        /// Stops the monitoring thread.
-        /// </summary>
-        public void Stop()
+    #region Initialization
+
+    private void InitRegistryKey(RegistryHive hive, string name)
+    {
+        switch (hive)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(null, "This instance is already disposed");
+            case RegistryHive.ClassesRoot:
+                _registryHive = HKEY_CLASSES_ROOT;
+                break;
+            case RegistryHive.CurrentConfig:
+                _registryHive = HKEY_CURRENT_CONFIG;
+                break;
+            case RegistryHive.CurrentUser:
+                _registryHive = HKEY_CURRENT_USER;
+                break;
+            case RegistryHive.LocalMachine:
+                _registryHive = HKEY_LOCAL_MACHINE;
+                break;
+            case RegistryHive.PerformanceData:
+                _registryHive = HKEY_PERFORMANCE_DATA;
+                break;
+            case RegistryHive.Users:
+                _registryHive = HKEY_USERS;
+                break;
+            default:
+                throw new InvalidEnumArgumentException("hive", (int)hive, typeof(RegistryHive));
+        }
+        _registrySubName = name;
+    }
 
-            lock (_threadLock)
-            {
-                Thread thread = _thread;
-                if (thread != null)
-                {
-                    _eventTerminate.Set();
-                    thread.Join();
-                }
-            }
+    private void InitRegistryKey(string name)
+    {
+        string[] nameParts = name.Split('\\');
+
+        switch (nameParts[0])
+        {
+            case "HKEY_CLASSES_ROOT":
+            case "HKCR":
+                _registryHive = HKEY_CLASSES_ROOT;
+                break;
+
+            case "HKEY_CURRENT_USER":
+            case "HKCU":
+                _registryHive = HKEY_CURRENT_USER;
+                break;
+
+            case "HKEY_LOCAL_MACHINE":
+            case "HKLM":
+                _registryHive = HKEY_LOCAL_MACHINE;
+                break;
+
+            case "HKEY_USERS":
+                _registryHive = HKEY_USERS;
+                break;
+
+            case "HKEY_CURRENT_CONFIG":
+                _registryHive = HKEY_CURRENT_CONFIG;
+                break;
+
+            default:
+                _registryHive = IntPtr.Zero;
+                throw new ArgumentException("The registry hive '" + nameParts[0] + "' is not supported", "value");
         }
 
-        private void MonitorThread()
+        _registrySubName = String.Join("\\", nameParts, 1, nameParts.Length - 1);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// <b>true</b> if this <see cref="RegistryMonitor"/> object is currently monitoring;
+    /// otherwise, <b>false</b>.
+    /// </summary>
+    public bool IsMonitoring => _thread != null;
+
+    /// <summary>
+    /// Start monitoring.
+    /// </summary>
+    public void Start()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(null, "This instance is already disposed");
+
+        lock (_threadLock)
         {
-            try
+            if (!IsMonitoring)
             {
-                ThreadLoop();
-            }
-            catch (Exception e)
-            {
-                OnError(e);
-            }
-            _thread = null;
-        }
-
-        private void ThreadLoop()
-        {
-            IntPtr registryKey;
-            int result = RegOpenKeyEx(_registryHive, _registrySubName, 0, STANDARD_RIGHTS_READ | KEY_QUERY_VALUE | KEY_NOTIFY,
-                                      out registryKey);
-            if (result != 0)
-                throw new Win32Exception(result);
-
-            try
-            {
-                AutoResetEvent _eventNotify = new AutoResetEvent(false);
-                WaitHandle[] waitHandles = new WaitHandle[] { _eventNotify, _eventTerminate };
-                while (!_eventTerminate.WaitOne(0, true))
-                {
-                    result = RegNotifyChangeKeyValue(registryKey, true, _regFilter, _eventNotify.Handle, true);
-                    if (result != 0)
-                        throw new Win32Exception(result);
-
-                    if (WaitHandle.WaitAny(waitHandles) == 0)
-                    {
-                        OnRegChanged();
-                    }
-                }
-            }
-            finally
-            {
-                if (registryKey != IntPtr.Zero)
-                {
-                    RegCloseKey(registryKey);
-                }
+                _eventTerminate.Reset();
+                _thread = new Thread(new ThreadStart(MonitorThread));
+                _thread.IsBackground = true;
+                _thread.Start();
             }
         }
     }
 
     /// <summary>
-    /// Filter for notifications reported by <see cref="RegistryMonitor"/>.
+    /// Stops the monitoring thread.
     /// </summary>
-    [Flags]
-    public enum RegChangeNotifyFilter
+    public void Stop()
     {
-        /// <summary>
-        /// Notify the caller if a subkey is added or deleted.
-        /// </summary>
-        Key = 1,
+        if (_disposed)
+            throw new ObjectDisposedException(null, "This instance is already disposed");
 
-        /// <summary>
-        /// Notify the caller of changes to the attributes of the key, such as the security descriptor information.
-        /// </summary>
-        Attribute = 2,
-
-        /// <summary>
-        /// Notify the caller of changes to a value of the key. This can include adding or deleting a value, or changing an existing value.
-        /// </summary>
-        Value = 4,
-
-        /// <summary>
-        /// Notify the caller of changes to the security of the key.
-        /// </summary>
-        Security = 8,
+        lock (_threadLock)
+        {
+            Thread thread = _thread;
+            if (thread != null)
+            {
+                _eventTerminate.Set();
+                thread.Join();
+            }
+        }
     }
+
+    private void MonitorThread()
+    {
+        try
+        {
+            ThreadLoop();
+        }
+        catch (Exception e)
+        {
+            OnError(e);
+        }
+        _thread = null;
+    }
+
+    private void ThreadLoop()
+    {
+        IntPtr registryKey;
+        int result = RegOpenKeyEx(_registryHive, _registrySubName, 0, STANDARD_RIGHTS_READ | KEY_QUERY_VALUE | KEY_NOTIFY,
+            out registryKey);
+        if (result != 0)
+            throw new Win32Exception(result);
+
+        try
+        {
+            AutoResetEvent _eventNotify = new AutoResetEvent(false);
+            WaitHandle[] waitHandles = new WaitHandle[] { _eventNotify, _eventTerminate };
+            while (!_eventTerminate.WaitOne(0, true))
+            {
+                result = RegNotifyChangeKeyValue(registryKey, true, _regFilter, _eventNotify.Handle, true);
+                if (result != 0)
+                    throw new Win32Exception(result);
+
+                if (WaitHandle.WaitAny(waitHandles) == 0)
+                {
+                    OnRegChanged();
+                }
+            }
+        }
+        finally
+        {
+            if (registryKey != IntPtr.Zero)
+            {
+                RegCloseKey(registryKey);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Filter for notifications reported by <see cref="RegistryMonitor"/>.
+/// </summary>
+[Flags]
+public enum RegChangeNotifyFilter
+{
+    /// <summary>
+    /// Notify the caller if a subkey is added or deleted.
+    /// </summary>
+    Key = 1,
+
+    /// <summary>
+    /// Notify the caller of changes to the attributes of the key, such as the security descriptor information.
+    /// </summary>
+    Attribute = 2,
+
+    /// <summary>
+    /// Notify the caller of changes to a value of the key. This can include adding or deleting a value, or changing an existing value.
+    /// </summary>
+    Value = 4,
+
+    /// <summary>
+    /// Notify the caller of changes to the security of the key.
+    /// </summary>
+    Security = 8,
 }


### PR DESCRIPTION
Introducing a config file in JSON format, properties can be accessed through ``UserConfig.Current``
This config currently holds for a new setting in the context menu a property for enabling and disabling notification toasts

Fixed some bugs, including:
- TaskView detection accuracy
- Textcolor beeing black on black in light mode

Some styling adjustments to the notification toasts were made:
- Initial opacity is now 0.5 instead of 1.0
- Staytime before fade out animation begins is set to 1000ms instead of 800ms