### PR TITLE
:bug: Fixing crash caused by Invoke()

### DIFF
--- a/src/Components/DesktopNameForm.cs
+++ b/src/Components/DesktopNameForm.cs
@@ -1,9 +1,14 @@
 ﻿using VirtualDesktopIndicator.Native;
+using Timer = System.Windows.Forms.Timer;
 
 namespace VirtualDesktopIndicator.Components;
 
 public class DesktopNameForm : Form
 {
+    
+    private const double FADE_STEP = 0.025;
+    private const int DELAY_TICKS = 15;
+    
     protected override CreateParams CreateParams
     {
         get
@@ -15,6 +20,9 @@ public class DesktopNameForm : Form
     }
 
     private readonly Label _displayLabel;
+    private readonly Timer _animationTimer;
+
+    private int _delayTicks;
     
     public DesktopNameForm(string font)
     {
@@ -30,6 +38,30 @@ public class DesktopNameForm : Form
             Dock = DockStyle.Fill,
             TextAlign = ContentAlignment.MiddleCenter
         });
+
+        _animationTimer = new()
+        {
+            Interval = 75
+        };
+        _animationTimer.Tick += AnimationTimer_OnTick;
+    }
+
+    private void AnimationTimer_OnTick(object? sender, EventArgs e)
+    {
+        if (_delayTicks-- > 0)
+        {
+            return;
+        }
+        
+        if (Opacity > 0)
+        {
+            Opacity -= FADE_STEP;
+        }
+        else
+        {
+            _animationTimer.Stop();
+            Hide();
+        }
     }
 
     public void Show(string displayName, Color foreColor, Color backColor)
@@ -43,6 +75,9 @@ public class DesktopNameForm : Form
         Width = TextRenderer.MeasureText(_displayLabel.Text, _displayLabel.Font).Width;
         Location = new(Screen.PrimaryScreen.Bounds.Width - Width,
             Screen.PrimaryScreen.Bounds.Height - Height);
+
+        _delayTicks = DELAY_TICKS;
+        _animationTimer.Start();
         
         Show();
     }

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -124,8 +124,6 @@ internal class DesktopNotifyIcon : IDisposable
     private bool _taskViewOpen;
     private bool _taskViewClick;
 
-    private Thread? _notificationAnimationThread;
-
     public DesktopNotifyIcon(IVirtualDesktopManager virtualDesktop)
     {
         _virtualDesktopManager = virtualDesktop;

--- a/src/Components/DesktopNotifyIcon.cs
+++ b/src/Components/DesktopNotifyIcon.cs
@@ -262,7 +262,7 @@ internal class DesktopNotifyIcon : IDisposable
             if (CurrentVirtualDesktop == _lastVirtualDesktop) return;
             if (UserConfig.Current.NotificationsEnabled)
             {
-                ShowDesktopNameToast();
+                _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColor, CurrentThemeColorContrast);
             }
 
             _cachedDisplayText = CurrentVirtualDesktop < 100 ? CurrentVirtualDesktop.ToString() : "++";
@@ -421,39 +421,6 @@ internal class DesktopNotifyIcon : IDisposable
         menu.Items.Add(exitItem);
 
         return menu;
-    }
-
-    private void ShowDesktopNameToast(int stayTime = 1000, int fadeTime = 25, double fadeStep = 0.025)
-    {
-        _desktopDisplay.Show(_virtualDesktopManager.CurrentDisplayName(), CurrentThemeColor, CurrentThemeColorContrast);
-
-        _notificationAnimationThread?.Interrupt();
-        _notificationAnimationThread = new(() =>
-        {
-            // Delay animation
-            try
-            {
-                Thread.Sleep(stayTime);
-            }
-            catch (Exception)
-            {
-                // Ignored
-            }
-
-            // Fade out
-            while (_desktopDisplay.Opacity > 0 && _lastVirtualDesktop == CurrentVirtualDesktop)
-            {
-                _desktopDisplay.Invoke(() => _desktopDisplay.Opacity -= fadeStep);
-                Thread.Sleep(fadeTime);
-            }
-
-            // Close form forever
-            if (_lastVirtualDesktop == CurrentVirtualDesktop)
-            {
-                _desktopDisplay.Invoke(() => _desktopDisplay.Hide());
-            }
-        });
-        _notificationAnimationThread.Start();
     }
 
     #endregion


### PR DESCRIPTION
When closing the app while it is animating the notification the app has crashed because Invoke() is unsafe

The problem is solved by moving the animation method from a thread into the form and using a safe winforms timer

Closes #11 